### PR TITLE
Feature/messaging to dmsg

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@ This document is to specify the tests currently missing within `dmsg` (and that 
 
 The individual entities of `dmsg` (`dmsg.Client` and `dmsg.Server`), should be capable of dealing with erroneous (and in the future, malicious) behaviour of remote entities.
 
-Note that even though `messaging-discovery` is also considered to be an entity of `dmsg`, however it's mechanics are simple and will not be tested here.
+Note that even though `dmsg-discovery` is also considered to be an entity of `dmsg`, however it's mechanics are simple and will not be tested here.
 
 **`failed_accepts_should_not_result_in_hang`**
 
@@ -52,7 +52,7 @@ Note that even though `messaging-discovery` is also considered to be an entity o
   - Server disconnects
 - Then:
   - Transports should be closed
-  
+
 **`server_disconnect_should_close_transports_while_communication_is_going_on`**
 
 - Given:
@@ -103,13 +103,13 @@ Also we need some kind of control panel from which we will run events. Events ma
   - second, we pick a corresponding number of events, each of them picked randomly
   - third, based on the probability of each event we calculate whether it will be executed or not
   - finally, we execute all the winner-events in goroutines
-  
+
 Before running each of the picked events we may need to take a snapshot of the whole system to check consistency
 
-Event type may be an struct containing function with some signature. Also this struct should have probability of the event, maybe the type of the event. 
+Event type may be an struct containing function with some signature. Also this struct should have probability of the event, maybe the type of the event.
 
 Running event should result in a snapshot of system's previous state. Snapshot should allow to simulate the event and return a new state. So this way we:
   - run a series of N events, get a series of N snapshots
   - for snapshots 0...N we pick (I)th snapshot and simulate an event on it which results in a new state. This new state may then be compared to the (I+1)th snapshot for consistency.
-  
+
 Snapshot should be able to dump the state in some form comfortable to examine in case something is wrong

--- a/client_conn.go
+++ b/client_conn.go
@@ -7,8 +7,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"github.com/SkycoinProject/skycoin/src/util/logging"
+	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/dmsg/cipher"
 )

--- a/disc/client.go
+++ b/disc/client.go
@@ -26,7 +26,7 @@ type APIClient interface {
 	AvailableServers(context.Context) ([]*Entry, error)
 }
 
-// HTTPClient represents a client that communicates with a messaging-discovery service through http, it
+// HTTPClient represents a client that communicates with a dmsg-discovery service through http, it
 // implements APIClient
 type httpClient struct {
 	client    http.Client
@@ -45,7 +45,7 @@ func NewHTTP(address string) APIClient {
 // Entry retrieves an entry associated with the given public key.
 func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry, error) {
 	var entry Entry
-	endpoint := fmt.Sprintf("%s/messaging-discovery/entry/%s", c.address, publicKey)
+	endpoint := fmt.Sprintf("%s/dmsg-discovery/entry/%s", c.address, publicKey)
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 
 // SetEntry creates a new Entry.
 func (c *httpClient) SetEntry(ctx context.Context, e *Entry) error {
-	endpoint := c.address + "/messaging-discovery/entry/"
+	endpoint := c.address + "/dmsg-discovery/entry/"
 	marshaledEntry, err := json.Marshal(e)
 	if err != nil {
 		return err
@@ -109,6 +109,7 @@ func (c *httpClient) SetEntry(ctx context.Context, e *Entry) error {
 		}()
 	}
 	if err != nil {
+		fmt.Println("req.Do err")
 		return err
 	}
 
@@ -123,6 +124,7 @@ func (c *httpClient) SetEntry(ctx context.Context, e *Entry) error {
 		if err != nil {
 			return err
 		}
+		fmt.Println("response msg err")
 		return errFromString(httpResponse.Message)
 	}
 	return nil
@@ -164,7 +166,7 @@ func (c *httpClient) UpdateEntry(ctx context.Context, sk cipher.SecKey, e *Entry
 // AvailableServers returns list of available servers.
 func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 	var entries []*Entry
-	endpoint := c.address + "/messaging-discovery/available_servers"
+	endpoint := c.address + "/dmsg-discovery/available_servers"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/noise/dh.go
+++ b/noise/dh.go
@@ -3,8 +3,8 @@ package noise
 import (
 	"io"
 
-	"github.com/flynn/noise"
 	"github.com/SkycoinProject/skycoin/src/cipher"
+	"github.com/flynn/noise"
 )
 
 // Secp256k1 implements `noise.DHFunc`.

--- a/server.go
+++ b/server.go
@@ -170,6 +170,7 @@ func (s *Server) updateDiscEntry(ctx context.Context) error {
 	if err != nil {
 		entry = disc.NewServerEntry(s.pk, 0, s.addr, 10)
 		if err := entry.Sign(s.sk); err != nil {
+			fmt.Println("err in sign")
 			return err
 		}
 		return s.dc.SetEntry(ctx, entry)

--- a/transport.go
+++ b/transport.go
@@ -7,8 +7,9 @@ import (
 	"net"
 	"sync"
 
-	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/skycoin/src/util/logging"
+
+	"github.com/SkycoinProject/dmsg/cipher"
 )
 
 // Errors related to REQUEST frames.

--- a/types.go
+++ b/types.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/SkycoinProject/dmsg/cipher"
 	"io"
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/SkycoinProject/dmsg/cipher"
 )
 
 const (

--- a/types_test.go
+++ b/types_test.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/SkycoinProject/dmsg/ioutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/SkycoinProject/dmsg/ioutil"
 )
 
 func Test_isInitiatorID(t *testing.T) {


### PR DESCRIPTION
 Changes:	
- Renamed messaging-server and messaging-discovery to dmsg-server and discovery

How to test this PR:
- Run `make test` while vendoring `dmsg@feature/messaging-to-dmsg` or integration tests with `skywire-services@feature/dmsg-server-remove-config`.