### PR TITLE
Set DEBUG level for logs of closed connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,7 +222,7 @@ func (c *Client) findOrConnectToServer(ctx context.Context, srvPK cipher.PubKey)
 
 	go func() {
 		err := conn.Serve(ctx)
-		conn.log.WithError(err).WithField("remoteServer", srvPK).Warn("connected with server closed")
+		conn.log.WithField("reason", err).WithField("remoteServer", srvPK).Debug("connection with server closed")
 		c.delConn(ctx, srvPK)
 
 		// reconnect logic.
@@ -299,7 +299,7 @@ func (c *Client) Close() error {
 		c.mx.Lock()
 		for _, conn := range c.conns {
 			if err := conn.Close(); err != nil {
-				log.WithError(err).Warn("Failed to close connection")
+				log.WithField("reason", err).Debug("Connection closed")
 			}
 		}
 		c.conns = make(map[cipher.PubKey]*ClientConn)

--- a/client_conn.go
+++ b/client_conn.go
@@ -275,7 +275,7 @@ func (c *ClientConn) close() (closed bool) {
 			}()
 		}
 		if err := c.Conn.Close(); err != nil {
-			log.WithError(err).Warn("Failed to close connection")
+			log.WithField("reason", err).Debug("Connection closed")
 		}
 		c.mx.Unlock()
 	})

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ func (r *NextConn) writeFrame(ft FrameType, p []byte) error {
 	if err := writeFrame(r.conn.Conn, MakeFrame(ft, r.id, p)); err != nil {
 		go func() {
 			if err := r.conn.Close(); err != nil {
-				log.WithError(err).Warn("Failed to close connection")
+				log.WithField("reason", err).Debug("Connection closed")
 			}
 		}()
 		return err
@@ -138,9 +138,9 @@ func (c *ServerConn) Serve(ctx context.Context, getConn getConnFunc) (err error)
 		}
 		c.mx.Unlock()
 
-		log.WithError(err).WithField("connCount", decrementServeCount()).Infoln("ClosingConn")
+		log.WithField("reason", err).WithField("connCount", decrementServeCount()).Debug("ClosingConn")
 		if err := c.Conn.Close(); err != nil {
-			log.WithError(err).Warn("Failed to close connection")
+			log.WithField("reason", err).Debug("Connection closed")
 		}
 	}()
 

--- a/transport.go
+++ b/transport.go
@@ -344,7 +344,7 @@ func (tp *Transport) Serve() {
 			case RequestType:
 				log.Warnln("Rejected [REQUEST]: ID already occupied, possibly malicious server.")
 				if err := tp.Conn.Close(); err != nil {
-					log.WithError(err).Warn("Failed to close connection")
+					log.WithField("reason", err).Debug("Connection closed")
 				}
 				return
 


### PR DESCRIPTION
Fixes #27 

Changes:	
- Change level of logs of closed connection to `DEBUG`

