### PR TITLE
Fix: Include config warnings and expose certain methods.

### DIFF
--- a/client.go
+++ b/client.go
@@ -199,7 +199,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// Range client's delegated servers.
 	// Attempt to connect to a delegated server.
 	for _, srvPK := range entry.Client.DelegatedServers {
-		dSes, err := ce.EnsureSession(ctx, srvPK)
+		dSes, err := ce.EnsureAndObtainSession(ctx, srvPK)
 		if err != nil {
 			continue
 		}
@@ -219,10 +219,10 @@ func (ce *Client) AllSessions() []ClientSession {
 	return ce.allClientSessions(ce.porter)
 }
 
-// EnsureSession attempts to obtain a session.
+// EnsureAndObtainSession attempts to obtain a session.
 // If the session does not exist, we will attempt to establish one.
 // It returns an error if the session does not exist AND cannot be established.
-func (ce *Client) EnsureSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
+func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
 	ce.sesMx.Lock()
 	defer ce.sesMx.Unlock()
 
@@ -256,7 +256,7 @@ func (ce *Client) ensureSession(ctx context.Context, entry *disc.Entry) error {
 
 // It is expected that the session is created and served before the context cancels, otherwise an error will be returned.
 // NOTE: This should not be called directly as it may lead to session duplicates.
-// Only `ensureSession` or `EnsureSession` should call this function.
+// Only `ensureSession` or `EnsureAndObtainSession` should call this function.
 func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
 	ce.log.WithField("remote_pk", entry.Static).Info("Dialing session...")
 

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/SkycoinProject/skycoin/src/util/logging"
+	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/dmsg/disc"
@@ -17,6 +18,13 @@ import (
 // Config configures a dmsg client entity.
 type Config struct {
 	MinSessions int
+}
+
+func (c Config) PrintWarnings(log logrus.FieldLogger) {
+	log = log.WithField("location", "dmsg.Config")
+	if c.MinSessions < 1 {
+		log.Warn("Field 'MinSessions' has value < 1 : This will disallow establishment of dmsg streams.")
+	}
 }
 
 // DefaultConfig returns the default configuration for a dmsg client entity.
@@ -40,15 +48,7 @@ type Client struct {
 
 // NewClient creates a dmsg client entity.
 func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Config) *Client {
-	if conf == nil {
-		conf = DefaultConfig()
-	}
-
 	c := new(Client)
-	c.conf = conf
-	c.porter = netutil.NewPorter(netutil.PorterMinEphemeral)
-	c.errCh = make(chan error, 10)
-	c.done = make(chan struct{})
 
 	c.EntityCommon.init(pk, sk, dc, logging.MustGetLogger("dmsg_client"))
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {
@@ -57,6 +57,15 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	c.EntityCommon.delSessionCallback = func(ctx context.Context) error {
 		return c.EntityCommon.updateClientEntry(ctx, c.done)
 	}
+
+	if conf == nil {
+		conf = DefaultConfig()
+	}
+	c.conf = conf
+
+	c.porter = netutil.NewPorter(netutil.PorterMinEphemeral)
+	c.errCh = make(chan error, 10)
+	c.done = make(chan struct{})
 
 	return c
 }
@@ -187,7 +196,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// Range client's delegated servers.
 	// Attempt to connect to a delegated server.
 	for _, srvPK := range entry.Client.DelegatedServers {
-		dSes, err := ce.obtainSession(ctx, srvPK)
+		dSes, err := ce.ObtainSession(ctx, srvPK)
 		if err != nil {
 			continue
 		}
@@ -213,7 +222,10 @@ func (ce *Client) ensureSession(ctx context.Context, entry *disc.Entry) error {
 	return err
 }
 
-func (ce *Client) obtainSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
+// ObtainSession attempts to obtain a session.
+// If the session does not exist, we will attempt to establish one.
+// It returns an error if the session does not exist AND cannot be established.
+func (ce *Client) ObtainSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
 	ce.sesMx.Lock()
 	defer ce.sesMx.Unlock()
 
@@ -231,7 +243,7 @@ func (ce *Client) obtainSession(ctx context.Context, srvPK cipher.PubKey) (Clien
 
 // It is expected that the session is created and served before the context cancels, otherwise an error will be returned.
 // NOTE: This should not be called directly as it may lead to session duplicates.
-// Only `ensureSession` or `obtainSession` should call this function.
+// Only `ensureSession` or `ObtainSession` should call this function.
 func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
 	ce.log.WithField("remote_pk", entry.Static).Info("Dialing session...")
 
@@ -250,7 +262,7 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (ClientSes
 	}
 	go func() {
 		ce.log.WithField("remote_pk", dSes.RemotePK()).Info("Serving session.")
-		if err := dSes.Serve(); !isClosed(ce.done) {
+		if err := dSes.serve(); !isClosed(ce.done) {
 			ce.errCh <- err
 			ce.delSession(ctx, dSes.RemotePK())
 		}

--- a/client_session.go
+++ b/client_session.go
@@ -61,12 +61,12 @@ func (cs *ClientSession) DialStream(dst Addr) (dStr *Stream, err error) {
 	return dStr, err
 }
 
-// Serve accepts incoming streams from remote clients.
-func (cs *ClientSession) Serve() error {
+// serve accepts incoming streams from remote clients.
+func (cs *ClientSession) serve() error {
 	defer func() {
 		if err := cs.Close(); err != nil {
 			cs.log.WithError(err).
-				Debug("On (*ClientSession).Serve() return, close client session resulted in error.")
+				Debug("On (*ClientSession).serve() return, close client session resulted in error.")
 		}
 	}()
 	for {

--- a/client_session.go
+++ b/client_session.go
@@ -66,7 +66,7 @@ func (cs *ClientSession) serve() error {
 	defer func() {
 		if err := cs.Close(); err != nil {
 			cs.log.WithError(err).
-				Debug("On (*clientSession).serve() return, close client session resulted in error.")
+				Debug("On (*ClientSession).serve() return, close client session resulted in error.")
 		}
 	}()
 	for {
@@ -87,7 +87,7 @@ func (cs *ClientSession) acceptStream() (dStr *Stream, err error) {
 		if err != nil {
 			if scErr := dStr.Close(); scErr != nil {
 				cs.log.WithError(scErr).
-					Debug("On (*clientSession).acceptStream() failure, close stream resulted in error.")
+					Debug("On (*ClientSession).acceptStream() failure, close stream resulted in error.")
 			}
 		}
 	}()

--- a/client_session.go
+++ b/client_session.go
@@ -66,7 +66,7 @@ func (cs *ClientSession) serve() error {
 	defer func() {
 		if err := cs.Close(); err != nil {
 			cs.log.WithError(err).
-				Debug("On (*ClientSession).serve() return, close client session resulted in error.")
+				Debug("On (*clientSession).serve() return, close client session resulted in error.")
 		}
 	}()
 	for {
@@ -87,7 +87,7 @@ func (cs *ClientSession) acceptStream() (dStr *Stream, err error) {
 		if err != nil {
 			if scErr := dStr.Close(); scErr != nil {
 				cs.log.WithError(scErr).
-					Debug("On (*ClientSession).acceptStream() failure, close stream resulted in error.")
+					Debug("On (*clientSession).acceptStream() failure, close stream resulted in error.")
 			}
 		}
 	}()

--- a/entity_common.go
+++ b/entity_common.go
@@ -49,16 +49,26 @@ func (c *EntityCommon) session(pk cipher.PubKey) (*SessionCommon, bool) {
 	return dSes, ok
 }
 
-// ServerSession obtains a session as a server.
-func (c *EntityCommon) ServerSession(pk cipher.PubKey) (ServerSession, bool) {
+// serverSession obtains a session as a server.
+func (c *EntityCommon) serverSession(pk cipher.PubKey) (ServerSession, bool) {
 	ses, ok := c.session(pk)
 	return ServerSession{SessionCommon: ses}, ok
 }
 
-// ClientSession obtains a session as a client.
-func (c *EntityCommon) ClientSession(porter *netutil.Porter, pk cipher.PubKey) (ClientSession, bool) {
+// clientSession obtains a session as a client.
+func (c *EntityCommon) clientSession(porter *netutil.Porter, pk cipher.PubKey) (ClientSession, bool) {
 	ses, ok := c.session(pk)
 	return ClientSession{SessionCommon: ses, porter: porter}, ok
+}
+
+func (c *EntityCommon) allClientSessions(porter *netutil.Porter) []ClientSession {
+	c.sessionsMx.Lock()
+	sessions := make([]ClientSession, 0, len(c.sessions))
+	for _, ses := range c.sessions {
+		sessions = append(sessions, ClientSession{SessionCommon: ses, porter: porter})
+	}
+	c.sessionsMx.Unlock()
+	return sessions
 }
 
 // SessionCount returns the number of sessions.

--- a/server_session.go
+++ b/server_session.go
@@ -87,7 +87,7 @@ func (ss *ServerSession) serveStream(yStr *yamux.Stream) error {
 	}
 
 	// Obtain next session.
-	ss2, ok := ss.entity.ServerSession(req.DstAddr.PK)
+	ss2, ok := ss.entity.serverSession(req.DstAddr.PK)
 	if !ok {
 		return ErrReqNoSession
 	}


### PR DESCRIPTION
Fixes #44 

 Changes:	
- Added `Config.PrintWarnings()` method to print warnings to log.
- Exposed `Client` methods: `Session()`, `AllSessions()` and `EnsureAndObtainSessions()`.
