### PR TITLE
Change code 200 to 404 when no servers found in the discovery

### DIFF
--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -236,6 +236,12 @@ func (a *API) getAvailableServer() http.HandlerFunc {
 			return
 		}
 
+		if len(entries) == 0 {
+			const code = http.StatusNotFound
+			a.writeJSON(w, code, disc.HTTPMessage{Code: code, Message: disc.ErrKeyNotFound.Error()})
+			return
+		}
+
 		a.writeJSON(w, http.StatusOK, entries)
 	}
 }

--- a/cmd/dmsg-discovery/internal/api/get_available_servers_test.go
+++ b/cmd/dmsg-discovery/internal/api/get_available_servers_test.go
@@ -82,13 +82,17 @@ func TestGetAvailableServers(t *testing.T) {
 			name:            "get no entries",
 			endpoint:        "/dmsg-discovery/available_servers",
 			method:          http.MethodGet,
-			status:          http.StatusOK,
-			responseIsError: false,
+			status:          http.StatusNotFound,
+			responseIsError: true,
 			databaseAndEntries: func(t *testing.T) (store2.Storer, []*disc.Entry) {
 				db, err := store2.NewStore("mock", "")
 				require.NoError(t, err)
 
 				return db, []*disc.Entry{}
+			},
+			errorMessage: disc.HTTPMessage{
+				Message: disc.ErrKeyNotFound.Error(),
+				Code:    http.StatusNotFound,
 			},
 		},
 	}
@@ -122,9 +126,8 @@ func TestGetAvailableServers(t *testing.T) {
 				err = json.NewDecoder(rr.Body).Decode(&resMessage)
 				require.NoError(t, err)
 
-				require.Equal(t, tc.errorMessage, &resMessage)
+				require.Equal(t, tc.errorMessage, resMessage)
 			}
-
 		})
 	}
 }

--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -71,7 +71,7 @@ func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry) error {
 
 // AvailableServers implements Storer AvailableServers method for redisdb database
 func (r *redisStore) AvailableServers(ctx context.Context, maxCount int) ([]*disc.Entry, error) {
-	entries := make([]*disc.Entry, 0)
+	var entries []*disc.Entry
 
 	pks, err := r.client.SRandMemberN("servers", int64(maxCount)).Result()
 	if err != nil {
@@ -91,6 +91,7 @@ func (r *redisStore) AvailableServers(ctx context.Context, maxCount int) ([]*dis
 		var entry *disc.Entry
 		if err := json.Unmarshal([]byte(payload.(string)), &entry); err != nil {
 			log.WithError(err).Warnf("Failed to unmarshal payload %s", payload.(string))
+			continue
 		}
 		entries = append(entries, entry)
 	}


### PR DESCRIPTION
Part of #52 

 Changes:	
- Added additional check of the found servers slice len to return 404 from discovery in appropriate cases. The problem is that sometimes when visor spams `Discovering dmsg servers`, discovery shows a loot of 200s in logs. But additional logging on visor side shows that incoming servers array is actually empty
