### PR TITLE
Add Dockerfile for building docker images of dmsg server and discovery

### DIFF
--- a/docker/images/dmsg-discovery/Dockerfile
+++ b/docker/images/dmsg-discovery/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /dmsg
 RUN go build -o /release/dmsg-discovery ./cmd/dmsg-discovery
 
 # Build image
-FROM busybox
+FROM scratch
 
 COPY --from=builder /release/dmsg-discovery /usr/local/bin/dmsg-discovery
 ENTRYPOINT [ "dmsg-discovery" ]

--- a/docker/images/dmsg-discovery/Dockerfile
+++ b/docker/images/dmsg-discovery/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.13-alpine AS builder
+ARG CGO_ENABLED=0
+
+ENV CGO_ENABLED=${CGO_ENABLED} \
+	GOOS=linux  \
+	GOARCH=amd64 \
+	GO111MODULE=on
+
+COPY . /dmsg
+
+WORKDIR /dmsg
+
+# Build dmsg discovery
+RUN go build -o /release/dmsg-discovery ./cmd/dmsg-discovery
+
+# Build image
+FROM busybox
+
+COPY --from=builder /release/dmsg-discovery /usr/local/bin/dmsg-discovery
+ENTRYPOINT [ "dmsg-discovery" ]

--- a/docker/images/dmsg-server/Dockerfile
+++ b/docker/images/dmsg-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.13-alpine AS builder
+ARG CGO_ENABLED=0
+
+ENV CGO_ENABLED=${CGO_ENABLED} \
+	GOOS=linux  \
+	GOARCH=amd64 \
+	GO111MODULE=on
+
+COPY . /dmsg
+
+WORKDIR /dmsg
+
+# Build dmsg server
+RUN go build -o /release/dmsg-server ./cmd/dmsg-server
+
+# Build image
+FROM busybox
+
+COPY --from=builder /release/dmsg-server /usr/local/bin/dmsg-server
+ENTRYPOINT [ "dmsg-server" ]

--- a/docker/images/dmsg-server/Dockerfile
+++ b/docker/images/dmsg-server/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /dmsg
 RUN go build -o /release/dmsg-server ./cmd/dmsg-server
 
 # Build image
-FROM busybox
+FROM scratch
 
 COPY --from=builder /release/dmsg-server /usr/local/bin/dmsg-server
 ENTRYPOINT [ "dmsg-server" ]


### PR DESCRIPTION
Changes:	
- Add Dockerfiles for building docker images of dmsg server and dmsg discovery. I will config the docker images build on docker hub afterwards. 