### PR TITLE
Fix adding build info to binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ bin/
 
 dmsg-discovery
 dmsg-server
+dmsgpty-cli
+dmsgpty-host
+dmsgpty-ui

--- a/Makefile
+++ b/Makefile
@@ -99,13 +99,5 @@ attach-pty: ## Attach local dmsgpty tmux session.
 
 stop-all: stop-pty stop-dmsg stop-db ## Stop all local tmux sessions.
 
-# TODO(evanlinjin): We should get rid of this at some point.
-bin: ## Build `dmsg-discovery`, `dmsg-server`
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsg-discovery ./cmd/dmsg-discovery
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsg-server ./cmd/dmsg-server
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-cli ./cmd/dmsgpty-cli
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-host ./cmd/dmsgpty-host
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-ui ./cmd/dmsgpty-ui
-
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,42 @@
 .DEFAULT_GOAL := help
 .PHONY : check lint install-linters dep test bin build
 
+VERSION := $(shell git describe)
+
+RFC_3339 := "+%Y-%m-%dT%H:%M:%SZ"
+DATE := $(shell date -u $(RFC_3339))
+COMMIT := $(shell git rev-list -1 HEAD)
+
 OPTS?=GO111MODULE=on GOBIN=${PWD}/bin
-TEST_OPTS?=-race -tags no_ci -cover -timeout=5m
 BIN_DIR?=./bin
-BUILD_OPTS?=
+
+TEST_OPTS:=-tags no_ci -cover -timeout=5m
+
+RACE_FLAG:=-race
+GOARCH:=$(shell go env GOARCH)
+
+ifneq (,$(findstring 64,$(GOARCH)))
+    TEST_OPTS:=$(TEST_OPTS) $(RACE_FLAG)
+endif
+
+# TODO: Remove after https://github.com/etcd-io/bbolt/pull/201 is closed.
+DISABLE_CHECKPTR_FLAG:=-gcflags=all=-d=checkptr=0
+GO_VERSION:=$(shell go version)
+
+ifneq (,$(findstring go1.14,$(GO_VERSION)))
+    TEST_OPTS:=$(TEST_OPTS) $(DISABLE_CHECKPTR_FLAG)
+endif
+
+SKYWIRE_MAINNET := github.com/SkycoinProject/skywire-mainnet
+BUILDINFO_PATH := $(SKYWIRE_MAINNET)/pkg/util/buildinfo
+
+BUILDINFO_VERSION := -X $(BUILDINFO_PATH).version=$(VERSION)
+BUILDINFO_DATE := -X $(BUILDINFO_PATH).date=$(DATE)
+BUILDINFO_COMMIT := -X $(BUILDINFO_PATH).commit=$(COMMIT)
+
+BUILDINFO?=-ldflags="$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)"
+
+BUILD_OPTS?=$(BUILDINFO)
 
 check: lint test ## Run linters and tests
 
@@ -36,7 +68,7 @@ dep: ## Sorts dependencies
 	${OPTS} go mod tidy -v
 
 build: ## Build binaries into ./bin
-	${OPTS} go install ./cmd/*
+	${OPTS} go install ${BUILD_OPTS} ./cmd/*
 
 start-db: ## Init local database env.
 	source ./integration/env.sh && init_redis
@@ -70,7 +102,10 @@ stop-all: stop-pty stop-dmsg stop-db ## Stop all local tmux sessions.
 # TODO(evanlinjin): We should get rid of this at some point.
 bin: ## Build `dmsg-discovery`, `dmsg-server`
 	${OPTS} go build ${BUILD_OPTS} -o ./dmsg-discovery ./cmd/dmsg-discovery
-	${OPTS} go build ${BUILD_OPTS} -o ./dmsg-server  ./cmd/dmsg-server
+	${OPTS} go build ${BUILD_OPTS} -o ./dmsg-server ./cmd/dmsg-server
+	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-cli ./cmd/dmsgpty-cli
+	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-host ./cmd/dmsgpty-host
+	${OPTS} go build ${BUILD_OPTS} -o ./dmsgpty-ui ./cmd/dmsgpty-ui
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 .PHONY : check lint install-linters dep test bin build
 
-VERSION := $(shell git describe)
+VERSION := $(shell git describe --always)
 
 RFC_3339 := "+%Y-%m-%dT%H:%M:%SZ"
 DATE := $(shell date -u $(RFC_3339))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY : check lint install-linters dep test bin build
+.PHONY : check lint install-linters dep test build
 
 VERSION := $(shell git describe --always)
 


### PR DESCRIPTION
Fixes #83

 Changes:	
- Fix adding build info to binaries

How to test this PR:
- Run `make bin`
- Run any of built binaries in the repository folder and check if a version is displayed correctly in the binary logs
- Run `make build`
- Run any of built binaries in the `./bin` repository subfolder and check if a version is displayed correctly in the binary logs
