### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@
 .idea/
 bin/
 
-dmsg-discovery
-dmsg-server
-dmsgpty-cli
-dmsgpty-host
-dmsgpty-ui
+/dmsg-discovery
+/dmsg-server
+/dmsgpty-cli
+/dmsgpty-host
+/dmsgpty-ui


### PR DESCRIPTION
Without leading `/`, `cmd/dmsg-server` gets `.gitignore`'d in the `skywire-mainnet repository.
