### PR TITLE
Move buildinfo to dmsg repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ ifneq (,$(findstring 64,$(GOARCH)))
     TEST_OPTS:=$(TEST_OPTS) $(RACE_FLAG)
 endif
 
-SKYWIRE_MAINNET := github.com/SkycoinProject/skywire-mainnet
-BUILDINFO_PATH := $(SKYWIRE_MAINNET)/pkg/util/buildinfo
+DMSG_REPO := github.com/SkycoinProject/dmsg
+BUILDINFO_PATH := $(DMSG_REPO)/buildinfo
 
 BUILDINFO_VERSION := -X $(BUILDINFO_PATH).version=$(VERSION)
 BUILDINFO_DATE := -X $(BUILDINFO_PATH).date=$(DATE)
@@ -53,7 +53,7 @@ install-linters: ## Install linters
 	${OPTS} go get -u golang.org/x/tools/cmd/goimports
 
 format: ## Formats the code. Must have goimports installed (use make install-linters).
-	${OPTS} goimports -w -local github.com/SkycoinProject/dmsg .
+	${OPTS} goimports -w -local ${DMSG_REPO} .
 
 dep: ## Sorts dependencies
 	${OPTS} go mod download

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -1,0 +1,52 @@
+package buildinfo
+
+import (
+	"fmt"
+	"io"
+)
+
+const unknown = "unknown"
+
+var (
+	version = unknown
+	commit  = unknown
+	date    = unknown
+)
+
+// Version returns version from git describe.
+func Version() string {
+	return version
+}
+
+// Commit returns commit hash.
+func Commit() string {
+	return commit
+}
+
+// Date returns date of build in RFC3339 format.
+func Date() string {
+	return date
+}
+
+// Get returns build info summary.
+func Get() *Info {
+	return &Info{
+		Version: Version(),
+		Commit:  Commit(),
+		Date:    Date(),
+	}
+}
+
+// Info is build info summary.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
+// WriteTo writes build info summary to io.Writer.
+func (info *Info) WriteTo(w io.Writer) (int64, error) {
+	msg := fmt.Sprintf("Version %q built on %q against commit %q\n", info.Version, info.Date, info.Commit)
+	n, err := w.Write([]byte(msg))
+	return int64(n), err
+}

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -8,11 +8,11 @@ import (
 	"os"
 
 	"github.com/SkycoinProject/skycoin/src/util/logging"
-	"github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	logrussyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/spf13/cobra"
 
+	"github.com/SkycoinProject/dmsg/buildinfo"
 	"github.com/SkycoinProject/dmsg/cmd/dmsg-discovery/internal/api"
 	"github.com/SkycoinProject/dmsg/cmd/dmsg-discovery/internal/store"
 

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -12,12 +12,12 @@ import (
 	"path/filepath"
 
 	"github.com/SkycoinProject/skycoin/src/util/logging"
-	"github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	logrussyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/spf13/cobra"
 
 	"github.com/SkycoinProject/dmsg"
+	"github.com/SkycoinProject/dmsg/buildinfo"
 	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/dmsg/disc"
 )

--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"log"
 
-	"github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo"
 	"github.com/spf13/cobra"
 
 	"github.com/SkycoinProject/dmsg"
+	"github.com/SkycoinProject/dmsg/buildinfo"
 	"github.com/SkycoinProject/dmsg/cmdutil"
 	"github.com/SkycoinProject/dmsg/dmsgpty"
 )

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/SkycoinProject/skycoin/src/util/logging"
-	"github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -19,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/SkycoinProject/dmsg"
+	"github.com/SkycoinProject/dmsg/buildinfo"
 	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/dmsg/cmdutil"
 	"github.com/SkycoinProject/dmsg/disc"

--- a/cmd/dmsgpty-ui/commands/root.go
+++ b/cmd/dmsgpty-ui/commands/root.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/SkycoinProject/dmsg/buildinfo"
 	"github.com/SkycoinProject/dmsg/cmdutil"
 	"github.com/SkycoinProject/dmsg/dmsgpty"
 )

--- a/dmsghttp/http_transport_test.go
+++ b/dmsghttp/http_transport_test.go
@@ -126,7 +126,7 @@ func startDmsgEnv(t *testing.T, nSrvs, maxSessions int) disc.APIClient {
 	return dc
 }
 
-// nolint:noparam
+// nolint:unparam
 func newDmsgClient(t *testing.T, dc disc.APIClient, minSessions int, name string) *dmsg.Client {
 	pk, sk := cipher.GenerateKeyPair()
 


### PR DESCRIPTION
Partially fixes https://github.com/SkycoinProject/skywire-mainnet/issues/373

 Changes:	
- Move `buildinfo` to `dmsg` repo

How to test this PR:
- Run `make build`
- Run any built binary
- Check if the binary contains correct build info