### PR TITLE
Fix Redis mget nil panic

### DIFF
--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -91,6 +91,12 @@ func (r *redisStore) AvailableServers(ctx context.Context, maxCount int) ([]*dis
 	}
 
 	for _, payload := range payloads {
+		// if there's no record for this PK, nil is returned. The below
+		// type assertion will panic in this case, so we skip
+		if payload == nil {
+			continue
+		}
+
 		var entry *disc.Entry
 		if err := json.Unmarshal([]byte(payload.(string)), &entry); err != nil {
 			log.WithError(err).Warnf("Failed to unmarshal payload %s", payload.(string))


### PR DESCRIPTION
Changes:	
- Fixed panic happening if there's no record in discovery associated with the passed-in PK
