### PR TITLE
Allow small error in timestamp of received entry

### DIFF
--- a/disc/entry.go
+++ b/disc/entry.go
@@ -270,7 +270,7 @@ func (e *Entry) Validate() error {
 	latestAcceptable := now.Add(allowedEntryTimestampError) // in case when time on nodes mismatches a bit
 
 	if ts.After(latestAcceptable) || ts.Before(earliestAcceptable) {
-		log.Warnf("Entry timestamp: %v (now: %v)", ts, now)
+		log.Warnf("Entry timestamp %v is not correct (now: %v)", ts, now)
 		return ErrValidationOutdatedTime
 	}
 

--- a/disc/entry.go
+++ b/disc/entry.go
@@ -10,7 +10,11 @@ import (
 	"github.com/SkycoinProject/dmsg/cipher"
 )
 
-const currentVersion = "0.0.1"
+const (
+	currentVersion             = "0.0.1"
+	entryLifetime              = 1 * time.Minute
+	allowedEntryTimestampError = 100 * time.Millisecond
+)
 
 var (
 	// ErrKeyNotFound occurs in case when entry of public key is not found
@@ -262,7 +266,11 @@ func (e *Entry) Validate() error {
 	}
 
 	now, ts := time.Now(), time.Unix(0, e.Timestamp)
-	if ts.After(now) || ts.Before(now.Add(-time.Minute)) {
+	earliestAcceptable := now.Add(-entryLifetime)
+	latestAcceptable := now.Add(allowedEntryTimestampError) // in case when time on nodes mismatches a bit
+
+	if ts.After(latestAcceptable) || ts.Before(earliestAcceptable) {
+		log.Warnf("Entry timestamp: %v (now: %v)", ts, now)
 		return ErrValidationOutdatedTime
 	}
 


### PR DESCRIPTION
Attempt to fix https://github.com/SkycoinPro/skywire-services/issues/215

Changes:	
- Allow 100ms error in the timestamp of a received entry

How to test this PR:
- Watch `dmsg-discovery` logs for `422` error (the changes were uploaded to the test deployment)